### PR TITLE
corrects url for 3dprintingnerd.com

### DIFF
--- a/sections/why-maker-box.liquid
+++ b/sections/why-maker-box.liquid
@@ -328,7 +328,7 @@ text-transform: uppercase;
                 <div class='quote'>
                 <h3>"[…] because of this box, the samples I got, I like how it performs - I would buy this filament.
                 […] and that’s the point of this. To try out a filament to see if you want to buy a larger roll of it… and I’m going to buy a larger roll of it because this is freaking cool."</h3>
-                <h3>- Joel from <a href='the3dprintingnerd.com'>3D Printing Nerd</a> on the virtues of our Maker Box subscriptions</h3>
+                <h3>- Joel from <a href='https://the3dprintingnerd.com'>3D Printing Nerd</a> on the virtues of our Maker Box subscriptions</h3>
             </div>
             </div>
         </div>


### PR DESCRIPTION
without protocol specified in the link the href/router attempts to resolve as a page by the domain name, sending the user to https://boxmountainllc.com/pages/the3dprintingnerd.com

![Untitled](https://user-images.githubusercontent.com/622118/93952701-1fea3180-fd0f-11ea-9fe8-549825a91098.gif)